### PR TITLE
Adding license key to package.json in order to have npm display the license

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
 	"dependencies" : [],
 	"repository" : {"type": "git", "url": "git://github.com/openexchangerates/accounting.js.git"},
 	"main" : "accounting.js",
-	"version" : "0.4.2"
+	"version" : "0.4.2",
+	"license": "MIT"
 }


### PR DESCRIPTION
Implemented https://docs.npmjs.com/files/package.json#license

So that the license will be displayed at https://www.npmjs.com/package/accounting
